### PR TITLE
feat: Allow shared DynamoDB table to be used for state

### DIFF
--- a/src/kinesis/consumer.py
+++ b/src/kinesis/consumer.py
@@ -131,7 +131,7 @@ class KinesisConsumer(object):
             # we should try to start a shard reader if the shard id specified isn't in our shards
             if shard_data['ShardId'] not in self.shards:
                 if 'EndingSequenceNumber' in shard_data['SequenceNumberRange']:
-                    log.info("Shard %s closed, skipping shard reader creation...", shard_data['ShardId'])
+                    log.debug("Shard %s closed, skipping shard reader creation...", shard_data['ShardId'])
                     continue
 
                 log.info("Shard reader for %s does not exist, creating...", shard_data['ShardId'])

--- a/src/kinesis/consumer.py
+++ b/src/kinesis/consumer.py
@@ -98,9 +98,6 @@ class KinesisConsumer(object):
         self.stream_data = None
         self.run = True
 
-    def state_shard_id(self, shard_id):
-        return '_'.join([self.stream_name, shard_id])
-
     def shutdown_shard_reader(self, shard_id):
         try:
             self.shards[shard_id].shutdown()
@@ -117,7 +114,7 @@ class KinesisConsumer(object):
         for shard_data in self.stream_data['StreamDescription']['Shards']:
             # see if we can get a lock on this shard id
             try:
-                shard_locked = self.state.lock_shard(self.state_shard_id(shard_data['ShardId']), self.LOCK_DURATION)
+                shard_locked = self.state.lock_shard(shard_data['ShardId'], self.LOCK_DURATION)
             except AttributeError:
                 # no self.state
                 pass
@@ -135,7 +132,7 @@ class KinesisConsumer(object):
             if shard_data['ShardId'] not in self.shards:
                 log.info("Shard reader for %s does not exist, creating...", shard_data['ShardId'])
                 try:
-                    iterator_args = self.state.get_iterator_args(self.state_shard_id(shard_data['ShardId']))
+                    iterator_args = self.state.get_iterator_args(shard_data['ShardId'])
                 except AttributeError:
                     # no self.state
                     iterator_args = dict(ShardIteratorType='LATEST')
@@ -196,7 +193,6 @@ class KinesisConsumer(object):
                     except six.moves.queue.Empty:
                         pass
                     else:
-                        state_shard_id = self.state_shard_id(shard_id)
                         for item in resp['Records']:
                             if not self.run:
                                 break
@@ -205,7 +201,7 @@ class KinesisConsumer(object):
                             yield item
 
                             try:
-                                self.state.checkpoint(state_shard_id, item['SequenceNumber'])
+                                self.state.checkpoint(shard_id, item['SequenceNumber'])
                             except AttributeError:
                                 # no self.state
                                 pass

--- a/src/kinesis/consumer.py
+++ b/src/kinesis/consumer.py
@@ -130,6 +130,10 @@ class KinesisConsumer(object):
 
             # we should try to start a shard reader if the shard id specified isn't in our shards
             if shard_data['ShardId'] not in self.shards:
+                if 'EndingSequenceNumber' in shard_data['SequenceNumberRange']:
+                    log.info("Shard %s closed, skipping shard reader creation...", shard_data['ShardId'])
+                    continue
+
                 log.info("Shard reader for %s does not exist, creating...", shard_data['ShardId'])
                 try:
                     iterator_args = self.state.get_iterator_args(shard_data['ShardId'])

--- a/src/kinesis/state.py
+++ b/src/kinesis/state.py
@@ -33,8 +33,8 @@ class DynamoDB(object):
         if shard_id not in self.shards:
             return iterator_args
 
-        heartbeat = self.shards[shard_id]['heartbeat']
-        last_sequence_number = self.shards[shard_id]['checkpoint']
+        heartbeat = self.shards[shard_id].get('heartbeat')
+        last_sequence_number = self.shards[shard_id].get('checkpoint')
 
         if not heartbeat or not last_sequence_number:
             return iterator_args

--- a/src/kinesis/state.py
+++ b/src/kinesis/state.py
@@ -98,7 +98,7 @@ class DynamoDB(object):
         try:
             # Do a consistent read to get the current document for our shard id
             resp = self.dynamo_table.get_item(Key=self.key, ConsistentRead=True)
-            self.shards[shard_id] = resp['Item']
+            self.shards = resp['Item']['shards']
         except KeyError:
             # if there's no Item in the resp then the document didn't exist
             pass

--- a/src/kinesis/state.py
+++ b/src/kinesis/state.py
@@ -154,8 +154,7 @@ class DynamoDB(object):
             # lock at the same time.
             self.dynamo_table.update_item(
                 Key=self.key,
-                UpdateExpression="SET shards = :empty",
-                ConditionExpression="attribute_not_exists(shards)",
+                UpdateExpression="SET shards = if_not_exists(shards, :empty)",
                 ExpressionAttributeValues={
                     ':empty': {}
                 },

--- a/src/kinesis/state.py
+++ b/src/kinesis/state.py
@@ -113,7 +113,7 @@ class DynamoDB(object):
             # all other client errors just get re-raised
             raise
         else:
-            if fqdn != self.shards[shard_id]['fqdn'] and now < self.shards[shard_id]['expires']:
+            if shard_id in self.shards and fqdn != self.shards[shard_id]['fqdn'] and now < self.shards[shard_id]['expires']:
                 # we don't hold the lock and it hasn't expired
                 log.debug("Not starting reader for shard %s -- locked by %s until %s",
                           shard_id, self.shards[shard_id]['fqdn'], self.shards[shard_id]['expires'])

--- a/src/kinesis/state.py
+++ b/src/kinesis/state.py
@@ -76,9 +76,11 @@ class DynamoDB(object):
                     attribute_not_exists(shards.#shard_id.checkpoint) OR
                     shards.#shard_id.checkpoint < :seq
                 """,
+                ExpressionAttributeNames={
+                    "#shard_id": shard_id
+                },
                 ExpressionAttributeValues={
                     ":heartbeat": heartbeat,
-                    ":shard_id": shard_id,
                     ":seq": seq,
                 }
             )
@@ -132,12 +134,14 @@ class DynamoDB(object):
                     shards.#shard_id.fqdn = :current_fqdn AND
                     shards.#shard_id.expires = :current_expires
                 """,
+                ExpressionAttributeNames={
+                    "#shard_id": shard_id
+                },
                 ExpressionAttributeValues={
                     ':new_fqdn': fqdn,
                     ':new_expires': expires,
                     ':current_fqdn': self.shards[shard_id]['fqdn'],
                     ':current_expires': self.shards[shard_id]['expires'],
-                    ':shard_id': shard_id
                 }
             )
             self.shards[shard_id].update({


### PR DESCRIPTION
#### Context

The current implementation for persisting state requires it's own DynamoDB table, which is not ideal from an infra standpoint.

#### Changes

- Updated `DynamoDB` to nest its data, such that multiple consumers using different streams can share the same table. Sample entry:
    ```json
    {
     "consumerGroup": "my-consumer",
     "streamName": "my-stream",
     "shards": {
      "shardId-000000000003": {
       "checkpoint": "49642932284673422822815917984352610300161935750375407666",
       "expires": 1691555151,
       "fqdn": "ip-10-100-100-100.ec2.internal",
       "heartbeat": "2023-08-08T09:13:04.812345Z"
      },
      "shardId-000000000004": {
       "checkpoint": "49643400008393912161303560224493580653147207038771658818",
       "expires": 1691555151,
       "fqdn": "ip-10-123-456-789.ec2.internal",
       "heartbeat": "2023-08-09T04:23:27.471404Z"
      },
      "shardId-000000000005": {
       "checkpoint": "49643400008416212906502090855437523611213524902537592914",
       "expires": 1691555151,
       "fqdn": "ip-10-123-456-789.ec2.internal",
       "heartbeat": "2023-08-09T04:23:27.870805Z"
      }
     }
    }
    ```
- Updated `KinesisConsumer`
  - Skip `ShardReader` creation for closed shards
  - Reverted shard name to just the standard shard id